### PR TITLE
Fix: Boton dice 'Ver Partidos' en modulo Partidos

### DIFF
--- a/sergiobets_unified.py
+++ b/sergiobets_unified.py
@@ -894,6 +894,11 @@ class SergioBetsUnified:
         self._filter_bar.grid(row=1, column=0, sticky='ew')
         self._stats_row.grid(row=2, column=0, sticky='ew')
         self._tabs_frame.grid(row=3, column=0, sticky='ew', pady=(0, 6))
+        # Update button text based on mode
+        if mode == 'partidos':
+            self._gen_btn.configure(text="Ver Partidos")
+        else:
+            self._gen_btn.configure(text="Generar Pronosticos")
         # Show/hide scroll frames based on mode
         self.sf_predicciones.grid_forget()
         self.sf_partidos.grid_forget()


### PR DESCRIPTION
## Summary

Dynamically updates the main action button text based on the active sidebar module. When the user navigates to **Partidos**, the button now reads "Ver Partidos" instead of "Generar Pronosticos". When navigating back to **Pronosticos** (or any other mode that shows the filter bar), it reverts to "Generar Pronosticos".

The change is in `_show_main_content()`, which is called whenever the user clicks Pronosticos or Partidos in the sidebar.

## Review & Testing Checklist for Human

- [ ] **Verify button text changes when switching between Pronosticos ↔ Partidos** — click each sidebar item and confirm the button label updates correctly
- [ ] **Confirm button still triggers the correct action** — the `command` binding (`self.buscar_en_hilo`) is unchanged, so clicking "Ver Partidos" should still load matches as before

### Notes
- This was not tested on a live GUI (built on a headless server). Visual verification on Windows is recommended.
- No logic or functionality was changed — only the displayed button label.

Link to Devin session: https://app.devin.ai/sessions/a75fef941bba46638288ffc205b79c1e