### PR TITLE
Clean: Eliminar stats, tabs y filtros innecesarios del modulo Partidos

### DIFF
--- a/sergiobets_unified.py
+++ b/sergiobets_unified.py
@@ -669,15 +669,17 @@ class SergioBetsUnified:
         self.combo_ligas.set('Todas')
         self.combo_ligas.bind('<<ComboboxSelected>>', self.on_liga_changed)
 
-        tk.Label(fbar, text="Corners", bg=palette['header_bg'], fg=palette['muted'],
-                 font=('Segoe UI', 9)).pack(side='left', padx=(0, 4))
+        self._corners_lbl = tk.Label(fbar, text="Corners", bg=palette['header_bg'], fg=palette['muted'],
+                 font=('Segoe UI', 9))
+        self._corners_lbl.pack(side='left', padx=(0, 4))
         self._combo_corners = ttk.Combobox(fbar, state='readonly', width=12,
                                            values=['Todos', 'Over 8.5', 'Over 9.5', 'Over 10.5'])
         self._combo_corners.pack(side='left', padx=(0, 16))
         self._combo_corners.set('Todos')
 
-        tk.Label(fbar, text="Confianza", bg=palette['header_bg'], fg=palette['muted'],
-                 font=('Segoe UI', 9)).pack(side='left', padx=(0, 4))
+        self._conf_lbl = tk.Label(fbar, text="Confianza", bg=palette['header_bg'], fg=palette['muted'],
+                 font=('Segoe UI', 9))
+        self._conf_lbl.pack(side='left', padx=(0, 4))
         self._combo_conf = ttk.Combobox(fbar, state='readonly', width=14,
                                         values=['Todas', 'Alta (>80%)', 'Media (60-80%)', 'Baja (<60%)'])
         self._combo_conf.pack(side='left', padx=(0, 16))
@@ -892,13 +894,25 @@ class SergioBetsUnified:
         self._current_main_mode = mode
         self._scroll_container.grid(row=4, column=0, sticky='nsew', padx=20)
         self._filter_bar.grid(row=1, column=0, sticky='ew')
-        self._stats_row.grid(row=2, column=0, sticky='ew')
-        self._tabs_frame.grid(row=3, column=0, sticky='ew', pady=(0, 6))
-        # Update button text based on mode
+        # Update button text and show/hide elements based on mode
         if mode == 'partidos':
             self._gen_btn.configure(text="Ver Partidos")
+            # Hide stats, tabs, corners and confianza filters for Partidos
+            self._stats_row.grid_forget()
+            self._tabs_frame.grid_forget()
+            self._corners_lbl.pack_forget()
+            self._combo_corners.pack_forget()
+            self._conf_lbl.pack_forget()
+            self._combo_conf.pack_forget()
         else:
             self._gen_btn.configure(text="Generar Pronosticos")
+            self._stats_row.grid(row=2, column=0, sticky='ew')
+            self._tabs_frame.grid(row=3, column=0, sticky='ew', pady=(0, 6))
+            # Restore corners and confianza filters
+            self._corners_lbl.pack(side='left', padx=(0, 4))
+            self._combo_corners.pack(side='left', padx=(0, 16))
+            self._conf_lbl.pack(side='left', padx=(0, 4))
+            self._combo_conf.pack(side='left', padx=(0, 16))
         # Show/hide scroll frames based on mode
         self.sf_predicciones.grid_forget()
         self.sf_partidos.grid_forget()


### PR DESCRIPTION
## Summary

Simplifies the **Partidos** module view so it only shows the **Fecha** and **Liga** filters. When the user navigates to Partidos via the sidebar, the following elements are now hidden:
- Stats cards row (Pronosticos generados, Partidos analizados, Promedio confianza)
- Content tabs (Picks Recomendados, Todos los Partidos, Historial, Alto Valor Esperado)
- Corners filter
- Confianza filter

When navigating back to **Pronosticos**, all elements are restored. Also carries forward the button text change from PR #26 ("Ver Partidos" vs "Generar Pronosticos").

Implementation: The Corners and Confianza labels are now stored as instance variables (`self._corners_lbl`, `self._conf_lbl`) so they can be toggled with `pack_forget()` / `pack()`.

## Review & Testing Checklist for Human

- [ ] **Verify filter widget ordering after toggling**: The Corners/Confianza widgets are re-packed via `pack(side='left')` each time you switch back to Pronosticos. Confirm they appear in the correct order (Fecha → Liga → Corners → Confianza → [button on right]) and don't shift position after switching Partidos → Pronosticos multiple times.
- [ ] **Confirm Partidos view shows only Fecha + Liga + "Ver Partidos" button** — no stats cards, no tabs, no Corners/Confianza dropdowns visible.
- [ ] **Confirm Pronosticos view is unchanged** — stats cards, tabs, and all four filters still appear correctly.

**Test plan:** Run `python sergiobets_unified.py`, click Partidos in the sidebar (verify clean view), click Pronosticos (verify everything restores), toggle back and forth 3+ times to check for layout drift.

### Notes
- Not tested visually — built on a headless server. Manual verification on Windows is required.
- The `else` branch in `_show_main_content` also covers the legacy 'dashboard' mode (show both), which retains the original behavior of showing all filter bar elements.

Link to Devin session: https://app.devin.ai/sessions/a75fef941bba46638288ffc205b79c1e