### PR TITLE
Fix: Boton Enviar ahora envia pronostico a Telegram

### DIFF
--- a/sergiobets_unified.py
+++ b/sergiobets_unified.py
@@ -2409,7 +2409,7 @@ class SergioBetsUnified:
             tk.Button(btns, text="Enviar", bg=p['primary'], fg='#FFFFFF',
                       font=('Segoe UI', 9, 'bold'), relief='flat', cursor='hand2',
                       bd=0, padx=10, pady=4,
-                      command=lambda v=var_cb: v.set(True)).pack()
+                      command=lambda v=var_cb: (v.set(True), self.enviar_predicciones_seleccionadas())).pack()
 
             # Liga tag at bottom
             liga = pred.get('liga', '')


### PR DESCRIPTION
## Summary

One-line fix: the "Enviar" button on each prediction card was broken — clicking it only toggled the checkbox to `True` but never actually triggered the Telegram send. Now it calls `enviar_predicciones_seleccionadas()` immediately after selecting the prediction.

**Before:** `command=lambda v=var_cb: v.set(True)` — checkbox checked, nothing sent.  
**After:** `command=lambda v=var_cb: (v.set(True), self.enviar_predicciones_seleccionadas())` — checkbox checked, then send triggered.

## Review & Testing Checklist for Human

- [ ] **Verify the button actually sends to Telegram** — click "Enviar" on a single prediction card and confirm it arrives in Telegram for premium users. This was not tested on a live environment.
- [ ] **Check behavior with multiple checked predictions** — `enviar_predicciones_seleccionadas()` sends *all* currently checked predictions, not just the one whose "Enviar" button was clicked. If the user manually checked other predictions before clicking "Enviar" on one card, all checked ones will be sent together. Verify this is acceptable behavior.
- [ ] **Confirm the bottom-bar "📌 Enviar" button still works** — it calls the same `enviar_predicciones_seleccionadas()` function and should be unaffected.

**Test plan:** Run `python sergiobets_unified.py`, generate predictions, click "Enviar" on one card, and verify the Telegram message arrives. Then check two predictions manually, click "Enviar" on a third, and confirm all three are sent.

### Notes
- The Alertas module send was already working correctly — only the per-card "Enviar" button in Pronosticos was affected.
- No logic changes to `enviar_predicciones_seleccionadas()` itself.

Link to Devin session: https://app.devin.ai/sessions/a75fef941bba46638288ffc205b79c1e