### PR TITLE
Fix: Checkbox de seleccion en Tracking funciona correctamente

### DIFF
--- a/sergiobets_unified.py
+++ b/sergiobets_unified.py
@@ -1759,12 +1759,22 @@ class SergioBetsUnified:
             card.grid(row=i + 1, column=0, sticky='ew', pady=3)
             card.grid_columnconfigure(2, weight=1)
 
-            # Checkbox for selection
+            # Checkbox for selection (toggle button for reliable dark-theme support)
             var = tk.BooleanVar(value=False)
             self._track_check_vars.append((var, bet))
-            tk.Checkbutton(card, variable=var, bg=p['card_bg'], activebackground=p['card_bg'],
-                           selectcolor=p['secondary_bg'], bd=0, highlightthickness=0).grid(
-                row=0, column=0, rowspan=3, sticky='ns', padx=(0, 8))
+            chk_btn = tk.Button(card, text="☐", bg=p['card_bg'], fg=p['muted'],
+                                font=('Segoe UI', 14), relief='flat', cursor='hand2',
+                                bd=0, highlightthickness=0, width=2, padx=0)
+            def make_toggle(v=var, b=chk_btn, palette=p):
+                def toggle():
+                    v.set(not v.get())
+                    if v.get():
+                        b.config(text="☑", fg=palette['primary'])
+                    else:
+                        b.config(text="☐", fg=palette['muted'])
+                return toggle
+            chk_btn.config(command=make_toggle())
+            chk_btn.grid(row=0, column=0, rowspan=3, sticky='ns', padx=(0, 4))
 
             # Team/match name
             partido_text = bet.get('partido', 'N/A')


### PR DESCRIPTION
## Summary

Replaces the `tk.Checkbutton` widget in the Tracking page bet cards with a custom `tk.Button` toggle. The native Checkbutton was not visually responding to clicks on Windows dark theme — the `selectcolor` matched the dark background, making the check/uncheck state invisible, so users couldn't tell if anything was selected.

The new approach uses a flat button that toggles between `☐` (unchecked, muted color) and `☑` (checked, primary/accent color) on click, with the underlying `BooleanVar` still tracked for the bulk-delete flow (`_track_delete_selected`).

## Review & Testing Checklist for Human

- [ ] **Click the checkbox on several bet cards** in the Tracking page and confirm the icon visibly toggles between ☐ and ☑ with a color change
- [ ] **Select multiple bets and click "Eliminar Seleccionados"** — verify only the checked ones are deleted from `historial_predicciones.json`
- [ ] **Verify the ☐/☑ unicode characters render correctly on your Windows machine** — some system fonts may not support these glyphs, in which case you'd see empty squares or boxes

**Test plan:** Run `python sergiobets_unified.py`, navigate to Tracking, click checkboxes on a few bet cards, confirm visual toggle works. Then use "Eliminar Seleccionados" to verify the selection state is correctly read.

### Notes
- The closure pattern `def make_toggle(v=var, b=chk_btn, palette=p)` correctly captures per-iteration values via default arguments, avoiding the common Python loop-closure bug.
- This change is cosmetic/UX only — no logic changes to how selections or deletions work.

Link to Devin session: https://app.devin.ai/sessions/a75fef941bba46638288ffc205b79c1e