### PR TITLE
Dashboard: Quitar emojis de titulos de secciones

### DIFF
--- a/sergiobets_unified.py
+++ b/sergiobets_unified.py
@@ -1028,7 +1028,7 @@ class SergioBetsUnified:
                               highlightbackground=p['card_border'], highlightthickness=1)
         perf_card.grid(row=0, column=0, sticky='nsew', padx=(0, 8))
 
-        tk.Label(perf_card, text="📊  Rendimiento de Predicciones",
+        tk.Label(perf_card, text="Rendimiento de Predicciones",
                  bg=p['card_bg'], fg=p['fg'],
                  font=('Segoe UI', 12, 'bold')).pack(anchor='w', pady=(0, 16))
 
@@ -1056,7 +1056,7 @@ class SergioBetsUnified:
                                 highlightbackground=p['card_border'], highlightthickness=1)
         status_card.grid(row=0, column=1, sticky='nsew', padx=(8, 0))
 
-        tk.Label(status_card, text="🏆  Estado del Sistema",
+        tk.Label(status_card, text="Estado del Sistema",
                  bg=p['card_bg'], fg=p['fg'],
                  font=('Segoe UI', 12, 'bold')).pack(anchor='w', pady=(0, 16))
 
@@ -1084,7 +1084,7 @@ class SergioBetsUnified:
                                 highlightbackground=p['card_border'], highlightthickness=1)
         recent_card.grid(row=3, column=0, sticky='ew', pady=(0, 16))
 
-        tk.Label(recent_card, text="🕐  Actividad Reciente",
+        tk.Label(recent_card, text="Actividad Reciente",
                  bg=p['card_bg'], fg=p['fg'],
                  font=('Segoe UI', 12, 'bold')).pack(anchor='w', pady=(0, 12))
 


### PR DESCRIPTION
## Summary

Removes emoji prefixes from three Dashboard section titles as requested by the user:

- `📊  Rendimiento de Predicciones` → `Rendimiento de Predicciones`
- `🏆  Estado del Sistema` → `Estado del Sistema`
- `🕐  Actividad Reciente` → `Actividad Reciente`

Cosmetic-only change — no logic affected.

## Review & Testing Checklist for Human

- [ ] Verify the three section titles still look properly aligned and readable without the emoji prefixes (the extra leading whitespace was also removed)

### Notes
- The top-level "Panel de Control" title and KPI card icons are unchanged — only the three mid/bottom section headers were modified per the user's request.

Link to Devin session: https://app.devin.ai/sessions/a75fef941bba46638288ffc205b79c1e