### PR TITLE
Eliminar tabs de Pronosticos y boton Modo Claro del sidebar

### DIFF
--- a/sergiobets_unified.py
+++ b/sergiobets_unified.py
@@ -600,15 +600,6 @@ class SergioBetsUnified:
                 w.bind('<Enter>', lambda e, nid=nav_id: self._on_nav_hover(nid, True))
                 w.bind('<Leave>', lambda e, nid=nav_id: self._on_nav_hover(nid, False))
 
-        # Theme toggle at sidebar bottom
-        tog_f = tk.Frame(sidebar, bg=sb['bg'])
-        tog_f.pack(side='bottom', fill='x', padx=16, pady=16)
-        self._theme_toggle_btn = tk.Button(
-            tog_f, text="☀️ Modo Claro", bg=sb['hover'], fg=sb['text'],
-            font=('Segoe UI', 9), relief='flat', cursor='hand2', bd=0,
-            padx=10, pady=6, command=self._toggle_theme)
-        self._theme_toggle_btn.pack(fill='x')
-
         self._set_active_nav('dashboard')
 
         # ── CONTENT AREA ─────────────────────────────────────────
@@ -1331,8 +1322,9 @@ class SergioBetsUnified:
         palette = self.theme.apply(new_mode)
         self._palette = palette
         self._rebuild_theme(palette)
-        self._theme_toggle_btn.config(
-            text="🌙 Modo Oscuro" if new_mode == 'light' else "☀️ Modo Claro")
+        if hasattr(self, '_theme_toggle_btn'):
+            self._theme_toggle_btn.config(
+                text="🌙 Modo Oscuro" if new_mode == 'light' else "☀️ Modo Claro")
 
     def _update_clock(self):
         """Update the live Colombia clock every second"""

--- a/sergiobets_unified.py
+++ b/sergiobets_unified.py
@@ -719,28 +719,6 @@ class SergioBetsUnified:
             n_lbl.pack(anchor='w')
             self._stats_labels[sid] = {'card': card, 'value': v_lbl, 'name': n_lbl}
 
-        # ── Content tabs ─────────────────────────────────────────
-        tabs_f = tk.Frame(content, bg=palette['bg'], padx=20)
-        tabs_f.grid(row=3, column=0, sticky='ew', pady=(0, 6))
-        self._tabs_frame = tabs_f
-
-        tab_defs = [
-            ("picks",      "Picks Recomendados"),
-            ("todos",      "Todos los Partidos"),
-            ("historial",  "Historial"),
-            ("alto_valor", "Alto Valor Esperado"),
-        ]
-        for tid, label in tab_defs:
-            is_act = (tid == "picks")
-            bg = palette['tab_active'] if is_act else palette['tab_inactive']
-            fg = palette['tab_active_text'] if is_act else palette['tab_text']
-            lbl = tk.Label(tabs_f, text=label, bg=bg, fg=fg,
-                           font=('Segoe UI', 10, 'bold' if is_act else 'normal'),
-                           padx=16, pady=8, cursor='hand2')
-            lbl.pack(side='left', padx=(0, 4))
-            lbl.bind('<Button-1>', lambda e, t=tid: self._on_tab_click(t))
-            self._content_tab_btns[tid] = lbl
-
         # ── Scrollable content ───────────────────────────────────
         scroll_container = tk.Frame(content, bg=palette['bg'])
         scroll_container.grid(row=4, column=0, sticky='nsew', padx=20)
@@ -1398,8 +1376,9 @@ class SergioBetsUnified:
                 parts['name'].configure(bg=p['stats_bg'], fg=p['muted'])
                 for c in parts['card'].winfo_children():
                     c.configure(bg=p['stats_bg'])
-            # Update tabs
-            self._tabs_frame.configure(bg=p['bg'])
+            # Update tabs (if they exist)
+            if hasattr(self, '_tabs_frame'):
+                self._tabs_frame.configure(bg=p['bg'])
             for tid, lbl in self._content_tab_btns.items():
                 is_act = (tid == self._active_tab)
                 lbl.configure(


### PR DESCRIPTION
## Summary

Two UI cleanup changes requested by the user:

1. **Removes the four-tab navigation bar** ("Picks Recomendados", "Todos los Partidos", "Historial", "Alto Valor Esperado") from the Pronosticos module. The tabs frame, label widgets, and click bindings are all deleted.

2. **Removes the theme toggle button** ("☀️ Modo Claro") from the bottom of the sidebar.

Defensive `hasattr` guards were added in `_toggle_theme` and `_rebuild_theme` so that theme toggling doesn't crash when `_tabs_frame` or `_theme_toggle_btn` no longer exist.

## Review & Testing Checklist for Human

- [ ] **Visual spacing**: The scrollable content area is still at grid `row=4` (tabs were `row=3`). With `row=3` now empty, verify there isn't an unexpected gap between the stats cards and the predictions list. If there is, the grid row index should be decremented to `row=3`.
- [ ] **Theme toggle still works programmatically**: `_toggle_theme` method still exists but has no UI trigger now. If theme switching is needed from Ajustes or elsewhere, confirm it still works. If not, this is fine — the button was intentionally removed.
- [ ] **Dead code**: `_on_tab_click` method, `_content_tab_btns` dict, and `_toggle_theme` method still exist but are now unreachable from the UI. Not harmful, but worth noting for future cleanup.

**Test plan:** Run `python sergiobets_unified.py`, navigate to Pronosticos and confirm the tab bar is gone and predictions display correctly. Verify the sidebar bottom no longer shows the theme toggle button. Toggle theme from Ajustes (if available) to check for console errors.

### Notes
- The `_content_tab_btns` dict is initialized empty in `setup_gui` and is no longer populated, so all existing loops over it become safe no-ops.
- The "Historial" tab previously provided a shortcut to the Tracking page — that navigation path is removed, but Tracking remains accessible via the sidebar.

Link to Devin session: https://app.devin.ai/sessions/a75fef941bba46638288ffc205b79c1e