### PR TITLE
Formato de hora 12h AM/PM + Fix crash _tabs_frame

### DIFF
--- a/league_utils.py
+++ b/league_utils.py
@@ -69,7 +69,7 @@ def convertir_timestamp_unix(timestamp_unix):
             TZ_BOGOTA = timezone(timedelta(hours=-5))
             dt_utc = datetime.fromtimestamp(timestamp_unix, tz=timezone.utc)
             dt_bogota = dt_utc.astimezone(TZ_BOGOTA)
-            return dt_bogota.strftime("%H:%M")
+            return dt_bogota.strftime("%I:%M %p")
         except Exception as e:
             print(f"Error convirtiendo timestamp {timestamp_unix}: {e}")
             return "Por confirmar"

--- a/sergiobets_unified.py
+++ b/sergiobets_unified.py
@@ -1330,7 +1330,7 @@ class SergioBetsUnified:
         """Update the live Colombia clock every second"""
         try:
             now = hora_bogota()
-            time_str = now.strftime('%H:%M:%S')
+            time_str = now.strftime('%I:%M:%S %p')
             self._clock_lbl.config(text=time_str)
         except Exception:
             pass
@@ -2092,7 +2092,7 @@ class SergioBetsUnified:
                         if usuario.get('fecha_expiracion'):
                             try:
                                 fecha_exp = datetime.fromisoformat(usuario['fecha_expiracion'])
-                                expira = fecha_exp.strftime('%Y-%m-%d %H:%M')
+                                expira = fecha_exp.strftime('%Y-%m-%d %I:%M %p')
                             except Exception:
                                 expira = "Error fecha"
                         tag = 'even' if idx % 2 == 0 else 'odd'
@@ -4021,7 +4021,7 @@ Activa tu membresía ahora y empieza a ganar. ⚽💰"""
                                     try:
                                         from datetime import datetime
                                         fecha_exp = datetime.fromisoformat(usuario['fecha_expiracion'])
-                                        expira = fecha_exp.strftime('%Y-%m-%d %H:%M')
+                                        expira = fecha_exp.strftime('%Y-%m-%d %I:%M %p')
                                     except:
                                         expira = "Error fecha"
                                 

--- a/sergiobets_unified.py
+++ b/sergiobets_unified.py
@@ -850,7 +850,8 @@ class SergioBetsUnified:
         self._scroll_container.grid_forget()
         self._filter_bar.grid_forget()
         self._stats_row.grid_forget()
-        self._tabs_frame.grid_forget()
+        if hasattr(self, '_tabs_frame'):
+            self._tabs_frame.grid_forget()
         self._settings_frame.grid_forget()
         self._tracking_frame.grid_forget()
         self._usuarios_frame.grid_forget()
@@ -869,7 +870,8 @@ class SergioBetsUnified:
             self._gen_btn.configure(text="Ver Partidos")
             # Hide stats, tabs, corners and confianza filters for Partidos
             self._stats_row.grid_forget()
-            self._tabs_frame.grid_forget()
+            if hasattr(self, '_tabs_frame'):
+                self._tabs_frame.grid_forget()
             self._corners_lbl.pack_forget()
             self._combo_corners.pack_forget()
             self._conf_lbl.pack_forget()
@@ -877,7 +879,8 @@ class SergioBetsUnified:
         else:
             self._gen_btn.configure(text="Generar Pronosticos")
             self._stats_row.grid(row=2, column=0, sticky='ew')
-            self._tabs_frame.grid(row=3, column=0, sticky='ew', pady=(0, 6))
+            if hasattr(self, '_tabs_frame'):
+                self._tabs_frame.grid(row=3, column=0, sticky='ew', pady=(0, 6))
             # Restore corners and confianza filters
             self._corners_lbl.pack(side='left', padx=(0, 4))
             self._combo_corners.pack(side='left', padx=(0, 16))


### PR DESCRIPTION
## Summary

Two changes in this PR:

### 1. Time format: 24h → 12h AM/PM
All user-facing time displays changed from military/24-hour format (`%H:%M`) to 12-hour AM/PM format (`%I:%M %p`):
- **Live clock** in header: `14:30:00` → `02:30:00 PM`
- **Match times** in Partidos module (`league_utils.py`): `14:30` → `02:30 PM`
- **Premium expiration dates** in Usuarios (2 locations): `2026-04-15 14:30` → `2026-04-15 02:30 PM`

Internal timestamps (`.isoformat()`) and date-only formats (`%Y-%m-%d`) are unchanged.

### 2. Fix: App crashes on startup (`_tabs_frame` AttributeError)
PR #34 removed the tabs bar from Pronosticos but left 3 bare references to `self._tabs_frame` in `_hide_all_pages()` and `_show_main_content()`. This caused an immediate crash on startup. Added `hasattr` guards consistent with the existing guard in `_rebuild_theme`.

## Review & Testing Checklist for Human
- [ ] **Launch the app** after `git pull` — confirm it no longer crashes on startup (the `_tabs_frame` fix)
- [ ] **Check the live clock** in the header — should show 12h format with AM/PM (e.g., `02:30:15 PM`)
- [ ] **Navigate to Partidos** — match times should display in AM/PM format
- [ ] **Navigate to Usuarios** — premium expiration dates should show AM/PM
- [ ] **Switch between Pronosticos and Partidos** modules — verify no errors from the `_tabs_frame` guards

**Test plan**: Run `python sergiobets_unified.py`, verify the app opens without errors, check the clock format, browse through Partidos and Usuarios modules.

### Notes
- `%I` produces zero-padded hours (e.g., `02:30 PM` not `2:30 PM`). If non-padded is preferred, `%-I` works on Linux/Mac but not Windows — would need a different approach.
- The `hasattr` guards are a safe defensive fix. A cleaner long-term approach would be to fully remove all `_tabs_frame` references since the widget no longer exists.

Link to Devin session: https://app.devin.ai/sessions/a75fef941bba46638288ffc205b79c1e