### PR TITLE
Fix: /start muestra estado correcto de membresia premium activa

### DIFF
--- a/telegram_bot_listener.py
+++ b/telegram_bot_listener.py
@@ -62,7 +62,7 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
         else:
             mensaje_acceso = ""
     
-    mensaje = f"Bienvenido a 𝔹𝕖𝕥𝔾𝕖𝕟𝕚𝕦𝕏 \n\n¡Prepárate para ganar! \n\nTu acceso premium ha expirado o no tienes acceso premium.\nContacta soporte para renovarlo o adquiere una membresía."
+    mensaje = f"Bienvenido a 𝔹𝕖𝕥𝔾𝕖𝕟𝕚𝕦𝕏 \n\n¡Prepárate para ganar!{mensaje_acceso}"
     
     keyboard = [
         [
@@ -402,9 +402,25 @@ async def volver_menu_principal(update: Update, context: ContextTypes.DEFAULT_TY
     """Volver al menú principal"""
     query = update.callback_query
     user = query.from_user
+    user_id = user.id
     first_name = user.first_name
     
-    mensaje = f"Bienvenido a 𝔹𝕖𝕥𝔾𝕖𝕟𝕚𝕦𝕏 \n\n¡Prepárate para ganar! \n\nTu acceso premium ha expirado o no tienes acceso premium.\nContacta soporte para renovarlo o adquiere una membresía."
+    tiene_acceso = verificar_acceso(str(user_id))
+    if not tiene_acceso:
+        mensaje_acceso = "\n\n⚠️ Tu acceso premium ha expirado o no tienes acceso premium.\nContacta soporte para renovarlo o adquiere una membresía."
+    else:
+        usuario_info = access_manager.obtener_usuario(str(user_id))
+        if usuario_info and usuario_info.get('fecha_expiracion'):
+            from datetime import datetime
+            try:
+                fecha_exp = datetime.fromisoformat(usuario_info['fecha_expiracion'])
+                mensaje_acceso = f"\n\n👑 Acceso Premium Activo hasta: {fecha_exp.strftime('%Y-%m-%d %H:%M')}"
+            except:
+                mensaje_acceso = "\n\n👑 Acceso Premium Activo"
+        else:
+            mensaje_acceso = ""
+    
+    mensaje = f"Bienvenido a 𝔹𝕖𝕥𝔾𝕖𝕟𝕚𝕦𝕏 \n\n¡Prepárate para ganar!{mensaje_acceso}"
     
     keyboard = [
         [


### PR DESCRIPTION
## Summary

Fixes the Telegram bot `/start` command and "Volver al Menú" button to display the correct premium membership status instead of always showing "Tu acceso premium ha expirado."

**Root cause:** In `start_command`, the code correctly computed `mensaje_acceso` by calling `verificar_acceso()` (lines 50-63), but the final welcome message on line 65 was hardcoded to always say the user has no premium — the `mensaje_acceso` variable was never interpolated into the message string.

The same hardcoded message existed in `volver_menu_principal`, which had no membership check at all.

**Changes:**
- `start_command`: Replace hardcoded "no premium" text with `{mensaje_acceso}` so the computed status is actually used.
- `volver_menu_principal`: Add the same `verificar_acceso()` check and use `{mensaje_acceso}` so users returning to the main menu also see correct status.

## Review & Testing Checklist for Human

- [ ] **Test with an active premium subscriber**: Have a user with active membership send `/start` to the bot and verify they see "👑 Acceso Premium Activo hasta: YYYY-MM-DD HH:MM" instead of the expiration warning.
- [ ] **Test with a non-premium user**: Verify they still see the "⚠️ Tu acceso premium ha expirado" message.
- [ ] **Test "Volver al Menú" button**: After navigating into a submenu (e.g., Estadísticas), tap "Volver al Menú" and verify the membership status displays correctly there too.

**Recommended test plan**: Deploy the updated `telegram_bot_listener.py`, then use a Telegram account with active premium to send `/start` and navigate menus. Compare the displayed message with the user's actual status in `access_manager`.

### Notes
- The membership check logic is duplicated between `start_command` and `volver_menu_principal`. A future refactor could extract this into a shared helper function.
- The redundant `from datetime import datetime` import inside the function body (copied from `start_command`) is harmless since `datetime` is already imported at module level.

Link to Devin session: https://app.devin.ai/sessions/a75fef941bba46638288ffc205b79c1e