### PR TITLE
Fix: predicciones eliminadas ya no reaparecen al cambiar de pagina

### DIFF
--- a/sergiobets_unified.py
+++ b/sergiobets_unified.py
@@ -920,6 +920,8 @@ class SergioBetsUnified:
             self._build_tracking_content(self._palette)
             self._tracking_loaded = True
         self._tracking_frame.grid(row=1, column=0, rowspan=5, sticky='nsew', padx=20, pady=20)
+        # Always reload data from file to reflect any deletions or changes
+        self._track_filter_click(self._track_filtro.get())
         # Auto-update pending results in background
         self._track_auto_update()
 


### PR DESCRIPTION
## Summary

Fixes a bug where predictions deleted in the Track Record page would reappear after navigating to another module (e.g. Dashboard) and back.

**Root cause:** The tracking page was built once and cached (`_tracking_loaded` flag). When returning to the page, the stale UI was shown without reloading data from `historial_predicciones.json`, so deletions that had been written to disk were not reflected.

**Fix:** Call `_track_filter_click()` every time the tracking page is shown, which reloads data from the JSON file and rebuilds the prediction list.

## Review & Testing Checklist for Human

- [ ] **Test the deletion flow end-to-end**: Navigate to Tracking → delete a prediction → go to Dashboard → return to Tracking → verify the deleted prediction stays gone
- [ ] **Check for flicker on first load**: On initial visit, `_build_tracking_content` already calls `_track_filter_click("historico")` internally. The new line calls it again immediately after. Verify this doesn't cause a visible double-render or flicker

### Notes
- The reload runs synchronously on the main thread. For very large prediction histories, this could cause a brief UI freeze when navigating to Tracking. In practice the dataset is likely small enough that this is imperceptible.

Link to Devin session: https://app.devin.ai/sessions/a75fef941bba46638288ffc205b79c1e