### PR TITLE
Grafico: labels de barras en formato completo COP (sin abreviacion K)

### DIFF
--- a/sergiobets_unified.py
+++ b/sergiobets_unified.py
@@ -1413,11 +1413,7 @@ class SergioBetsUnified:
         for x1, x2, y_top, y_bot, pl in bar_positions:
             if pl != 0:
                 sign_char = '+' if pl > 0 else ''
-                # Format: use K for large values
-                if abs(pl) >= 1000:
-                    val_text = f"{sign_char}${pl / 1000:,.1f}K"
-                else:
-                    val_text = f"{sign_char}${pl:,.0f}"
+                val_text = f"{sign_char}${pl:,.0f}"
                 val_y = y_top - 12 if pl >= 0 else y_bot + 12
                 tx = (x1 + x2) / 2
                 val_color = '#10B981' if pl > 0 else '#EF4444'


### PR DESCRIPTION
## Summary

Removes the "K" shorthand formatting from bar value labels in the Rendimiento (performance) chart. Labels now always show the full peso amount (e.g. `+$11,200`) instead of abbreviating to `+$11.2K` for values ≥ 1,000. This was requested by the user who prefers seeing the complete COP values.

The Y-axis labels (which use a separate formatting path) are unaffected and still use the `K` suffix to avoid crowding.

## Review & Testing Checklist for Human

- [ ] **Visual check**: Open Rendimiento and verify bar labels show full values like `+$48,200` instead of `+$48.2K`. Confirm labels don't overlap or get cut off on days with large profit/loss values

### Notes
- This is a follow-up to PR #53 which overhauled the chart visuals. The label format change missed that merge window.
- Only the bar value labels changed; Y-axis tick labels still use `K` format via separate code.

Link to Devin session: https://app.devin.ai/sessions/a75fef941bba46638288ffc205b79c1e