### PR TITLE
Algoritmo V2 paralelo: sistema experimental independiente con boton V2 y tabla comparativa

### DIFF
--- a/ia_bets_v2.py
+++ b/ia_bets_v2.py
@@ -1,0 +1,949 @@
+"""
+ALGORITMO V2 - BetGeniuX Experimental Engine
+==============================================
+Motor de pronosticos experimental enfocado en RENTABILIDAD MAXIMA.
+
+Filosofia V2:
+  "Menos picks, mejor seleccion, cuotas mas altas = mas dinero"
+
+Diferencias clave vs V1:
+  1. ELIMINA apuestas defensivas (under goles, under corners, etc.)
+  2. PRIORIZA mercados con logica real:
+     - Ganador (1X2): solo cuando hay ventaja clara de forma/H2H
+     - BTTS SI: equipos goleadores con defensas permeables
+     - Over Goles: partidos con historial de muchos goles
+     - Corners Over: equipos con estilo ofensivo/presion alta
+     - Tarjetas Over: rivales historicos, arbitros estrictos
+     - Double Chance: cuando hay valor pero incertidumbre en el exacto
+  3. SCORING inteligente por tipo de mercado
+  4. CUOTAS altas: min 1.65, rango prioritario 1.75-2.10
+  5. MAX 3 picks/dia (configurable)
+  6. DIVERSIFICACION: no repetir el mismo tipo de mercado
+
+NO MODIFICA ia_bets.py — archivo completamente independiente.
+"""
+
+import json
+import os
+import hashlib
+from datetime import datetime
+from typing import List, Dict, Any, Optional, Tuple
+import numpy as np
+from scipy import stats
+
+# ── V2 Configuration ────────────────────────────────────────
+V2_ODDS_MIN = 1.65             # Cuota minima absoluta
+V2_ODDS_PRIORITY_MIN = 1.75    # Rango prioritario inferior
+V2_ODDS_PRIORITY_MAX = 2.10    # Rango prioritario superior
+V2_ODDS_MAX = 2.80             # Cuota maxima absoluta
+V2_EV_OVERRIDE_THRESHOLD = 0.15  # 15% EV para override fuera del rango
+V2_EV_MIN = 0.08              # 8% EV minimo (mas estricto que V1)
+V2_MAX_PICKS = 3               # Maximo picks por dia
+V2_MAX_SAME_MARKET = 2         # Maximo picks del mismo tipo de mercado
+
+# Mercados PROHIBIDOS en V2 (apuestas defensivas / perezosas)
+V2_MERCADOS_PROHIBIDOS = {
+    "under_05", "under_15", "under_25", "under_35", "under_45", "under_55",
+    "under_85", "under_95", "under_105", "under_115",
+    "under_35_cards", "under_45_cards", "under_55_cards",
+    "under_05_1h", "under_15_1h", "under_25_1h",
+    "under_05_2h", "under_15_2h", "under_25_2h",
+    "result_x", "result_x_1h", "result_x_2h",
+}
+
+# Umbrales de confianza MINIMA por tipo de mercado
+V2_CONFIDENCE_THRESHOLDS = {
+    "1X2": 0.48,
+    "BTTS": 0.55,
+    "Over/Under": 0.52,
+    "1H": 0.45,
+    "2H": 0.45,
+    "DC": 0.62,
+    "Corners": 0.50,
+    "Tarjetas": 0.50,
+    "Handicap": 0.45,
+}
+
+# Peso de cada factor en el scoring por tipo de mercado
+# [ev_weight, context_weight, prob_weight, range_bonus_weight]
+V2_MARKET_WEIGHTS = {
+    "1X2":        [0.30, 0.35, 0.20, 0.15],
+    "BTTS":       [0.35, 0.30, 0.20, 0.15],
+    "Over/Under": [0.30, 0.30, 0.25, 0.15],
+    "1H":         [0.35, 0.25, 0.25, 0.15],
+    "2H":         [0.35, 0.25, 0.25, 0.15],
+    "DC":         [0.25, 0.30, 0.30, 0.15],
+    "Corners":    [0.30, 0.35, 0.20, 0.15],
+    "Tarjetas":   [0.30, 0.35, 0.20, 0.15],
+    "Handicap":   [0.30, 0.30, 0.25, 0.15],
+}
+
+# ── Reutilizamos funciones de analisis de ia_bets ───────────
+from ia_bets import (
+    generar_semilla_partido,
+    es_liga_conocida,
+    calcular_probabilidades_1x2,
+    calcular_probabilidades_btts,
+    calcular_probabilidades_over_under,
+    calcular_probabilidades_primera_mitad,
+    calcular_probabilidades_tarjetas,
+    calcular_probabilidades_corners,
+    calcular_probabilidades_handicap,
+    analizar_rendimiento_equipos,
+    analizar_partido_completo,
+    _log_to_file,
+    LIGAS_CONOCIDAS,
+)
+
+_cache_predicciones_v2 = {}
+
+
+def limpiar_cache_predicciones_v2():
+    """Limpia el cache de predicciones V2"""
+    global _cache_predicciones_v2
+    _cache_predicciones_v2.clear()
+
+
+def cargar_configuracion_v2():
+    """Carga configuracion V2 desde config_app.json (si existe)"""
+    try:
+        from json_storage import cargar_json
+        config = cargar_json("config_app.json")
+        if config and "v2_odds_min" in config:
+            return {
+                "odds_min": config.get("v2_odds_min", V2_ODDS_MIN),
+                "odds_pri_min": config.get("v2_odds_priority_min", V2_ODDS_PRIORITY_MIN),
+                "odds_pri_max": config.get("v2_odds_priority_max", V2_ODDS_PRIORITY_MAX),
+                "odds_max": config.get("v2_odds_max", V2_ODDS_MAX),
+                "ev_min": config.get("v2_ev_min", V2_EV_MIN),
+                "max_picks": config.get("v2_max_picks", V2_MAX_PICKS),
+            }
+    except Exception:
+        pass
+    return {
+        "odds_min": V2_ODDS_MIN,
+        "odds_pri_min": V2_ODDS_PRIORITY_MIN,
+        "odds_pri_max": V2_ODDS_PRIORITY_MAX,
+        "odds_max": V2_ODDS_MAX,
+        "ev_min": V2_EV_MIN,
+        "max_picks": V2_MAX_PICKS,
+    }
+
+
+# ═══════════════════════════════════════════════════════════════
+#  ANALISIS CONTEXTUAL POR TIPO DE MERCADO
+# ═══════════════════════════════════════════════════════════════
+
+def _analizar_contexto_1x2(analisis: Dict[str, Any], mercado: str) -> float:
+    """
+    Analisis contextual para Ganador (1X2).
+    Factores: forma diferencial, H2H, localia, consistencia.
+    """
+    rend = analisis.get("rendimiento_equipos", {})
+    forma_local = rend.get("forma_local", 0.5)
+    forma_visit = rend.get("forma_visitante", 0.5)
+    h2h_goles = rend.get("h2h_goles_total", 2.7)
+
+    if mercado == "local":
+        forma_diff = forma_local - forma_visit
+        localia_bonus = 0.12
+        score = 0.5 + (forma_diff * 0.8) + localia_bonus
+        if h2h_goles > 2.5:
+            score += 0.05
+    elif mercado == "visitante":
+        forma_diff = forma_visit - forma_local
+        penalizacion = -0.08
+        score = 0.5 + (forma_diff * 0.8) + penalizacion
+        if forma_diff > 0.15:
+            score += 0.10
+    else:
+        return 0.0
+
+    return max(0.0, min(1.0, score))
+
+
+def _analizar_contexto_btts(analisis: Dict[str, Any]) -> float:
+    """
+    Analisis contextual para BTTS (Ambos Marcan).
+    Factores: goles promedio de ambos, defensas permeables, H2H, goles esperados.
+    """
+    rend = analisis.get("rendimiento_equipos", {})
+    goles_local = rend.get("goles_promedio_local", 1.3)
+    goles_visit = rend.get("goles_promedio_visitante", 1.3)
+    h2h_goles = rend.get("h2h_goles_total", 2.7)
+    ou_data = analisis.get("probabilidades_over_under", {})
+    goles_esperados = ou_data.get("goles_esperados", 2.7)
+
+    min_goles = min(goles_local, goles_visit)
+    score = 0.0
+
+    if min_goles >= 1.2:
+        score += 0.35
+    elif min_goles >= 0.9:
+        score += 0.20
+    else:
+        score += 0.05
+
+    if goles_esperados >= 2.8:
+        score += 0.25
+    elif goles_esperados >= 2.3:
+        score += 0.15
+    else:
+        score += 0.05
+
+    if h2h_goles >= 3.0:
+        score += 0.20
+    elif h2h_goles >= 2.5:
+        score += 0.12
+    else:
+        score += 0.05
+
+    balance = 1.0 - abs(goles_local - goles_visit) / 2.0
+    score += balance * 0.20
+
+    return max(0.0, min(1.0, score))
+
+
+def _analizar_contexto_over_goles(analisis: Dict[str, Any], linea: float) -> float:
+    """
+    Analisis contextual para Over Goles.
+    Factores: margen sobre linea, potencia ofensiva, H2H, forma.
+    """
+    rend = analisis.get("rendimiento_equipos", {})
+    goles_local = rend.get("goles_promedio_local", 1.3)
+    goles_visit = rend.get("goles_promedio_visitante", 1.3)
+    h2h_goles = rend.get("h2h_goles_total", 2.7)
+    ou_data = analisis.get("probabilidades_over_under", {})
+    goles_esperados = ou_data.get("goles_esperados", 2.7)
+
+    margen = goles_esperados - linea
+    if margen <= 0:
+        return 0.1
+
+    score = 0.0
+
+    if margen >= 1.0:
+        score += 0.35
+    elif margen >= 0.5:
+        score += 0.25
+    else:
+        score += 0.10
+
+    potencia = goles_local + goles_visit
+    if potencia >= 2.8:
+        score += 0.25
+    elif potencia >= 2.3:
+        score += 0.15
+    else:
+        score += 0.05
+
+    if h2h_goles > linea + 0.5:
+        score += 0.20
+    elif h2h_goles > linea:
+        score += 0.10
+
+    forma_local = rend.get("forma_local", 0.5)
+    forma_visit = rend.get("forma_visitante", 0.5)
+    if forma_local > 0.55 and forma_visit > 0.45:
+        score += 0.20
+    elif forma_local > 0.55 or forma_visit > 0.55:
+        score += 0.10
+
+    return max(0.0, min(1.0, score))
+
+
+def _analizar_contexto_corners(analisis: Dict[str, Any], linea: float) -> float:
+    """
+    Analisis contextual para Corners Over.
+    Factores: factor corners, estilo ofensivo, partido disputado, goles esperados.
+    """
+    rend = analisis.get("rendimiento_equipos", {})
+    corners_factor = rend.get("corners_promedio", 1.0)
+    forma_local = rend.get("forma_local", 0.5)
+    forma_visit = rend.get("forma_visitante", 0.5)
+    ou_data = analisis.get("probabilidades_over_under", {})
+    goles_esperados = ou_data.get("goles_esperados", 2.7)
+
+    score = 0.0
+
+    if corners_factor >= 1.15:
+        score += 0.30
+    elif corners_factor >= 1.0:
+        score += 0.20
+    elif corners_factor >= 0.85:
+        score += 0.10
+    else:
+        score += 0.02
+
+    diff_forma = abs(forma_local - forma_visit)
+    if diff_forma < 0.15:
+        score += 0.25
+    elif diff_forma < 0.25:
+        score += 0.15
+    else:
+        score += 0.05
+
+    if goles_esperados >= 2.8:
+        score += 0.20
+    elif goles_esperados >= 2.3:
+        score += 0.12
+    else:
+        score += 0.05
+
+    if forma_local > 0.5 and forma_visit > 0.4:
+        score += 0.25
+    elif forma_local > 0.5 or forma_visit > 0.5:
+        score += 0.12
+
+    penalty = max(0, (linea - 8.5) * 0.05)
+    score -= penalty
+
+    return max(0.0, min(1.0, score))
+
+
+def _analizar_contexto_tarjetas(analisis: Dict[str, Any], linea: float) -> float:
+    """
+    Analisis contextual para Tarjetas Over.
+    Factores: disciplina, intensidad, partido disputado, H2H.
+    """
+    rend = analisis.get("rendimiento_equipos", {})
+    tarjetas_factor = rend.get("tarjetas_promedio", 1.0)
+    forma_local = rend.get("forma_local", 0.5)
+    forma_visit = rend.get("forma_visitante", 0.5)
+    h2h_goles = rend.get("h2h_goles_total", 2.7)
+    ventaja = rend.get("ventaja_local", 0)
+
+    score = 0.0
+
+    if tarjetas_factor >= 1.2:
+        score += 0.30
+    elif tarjetas_factor >= 1.0:
+        score += 0.20
+    elif tarjetas_factor >= 0.8:
+        score += 0.10
+    else:
+        score += 0.02
+
+    diff_forma = abs(forma_local - forma_visit)
+    if diff_forma < 0.12:
+        score += 0.30
+    elif diff_forma < 0.22:
+        score += 0.18
+    else:
+        score += 0.05
+
+    if h2h_goles >= 3.0:
+        score += 0.20
+    elif h2h_goles >= 2.5:
+        score += 0.12
+    else:
+        score += 0.05
+
+    if abs(ventaja) < 0.15:
+        score += 0.20
+    elif abs(ventaja) < 0.25:
+        score += 0.10
+
+    penalty = max(0, (linea - 3.5) * 0.06)
+    score -= penalty
+
+    return max(0.0, min(1.0, score))
+
+
+def _analizar_contexto_dc(analisis: Dict[str, Any], mercado: str) -> float:
+    """
+    Analisis contextual para Double Chance (1X, X2, 12).
+    Factores: probabilidad combinada, forma, ventaja.
+    """
+    prob_1x2 = analisis.get("probabilidades_1x2", {})
+    rend = analisis.get("rendimiento_equipos", {})
+    forma_local = rend.get("forma_local", 0.5)
+    forma_visit = rend.get("forma_visitante", 0.5)
+
+    score = 0.0
+
+    if mercado == "1x":
+        prob_combinada = prob_1x2.get("local", 0.33) + prob_1x2.get("empate", 0.33)
+        if forma_local > forma_visit and forma_local > 0.5:
+            score += 0.30
+        else:
+            score += 0.10
+    elif mercado == "x2":
+        prob_combinada = prob_1x2.get("empate", 0.33) + prob_1x2.get("visitante", 0.33)
+        if forma_visit > forma_local and forma_visit > 0.5:
+            score += 0.30
+        else:
+            score += 0.10
+    elif mercado == "12":
+        prob_combinada = prob_1x2.get("local", 0.33) + prob_1x2.get("visitante", 0.33)
+        if forma_local > 0.5 and forma_visit > 0.45:
+            score += 0.25
+        else:
+            score += 0.10
+    else:
+        return 0.0
+
+    if prob_combinada >= 0.72:
+        score += 0.35
+    elif prob_combinada >= 0.62:
+        score += 0.25
+    else:
+        score += 0.10
+
+    ventaja = rend.get("ventaja_local", 0)
+    if abs(ventaja) > 0.15:
+        score += 0.20
+    elif abs(ventaja) > 0.08:
+        score += 0.10
+
+    return max(0.0, min(1.0, score))
+
+
+def _analizar_contexto_handicap(analisis: Dict[str, Any], mercado: str) -> float:
+    """Analisis contextual para Handicap Asiatico."""
+    rend = analisis.get("rendimiento_equipos", {})
+    forma_local = rend.get("forma_local", 0.5)
+    forma_visit = rend.get("forma_visitante", 0.5)
+    ventaja = rend.get("ventaja_local", 0)
+    h2h_goles = rend.get("h2h_goles_total", 2.7)
+
+    score = 0.0
+    es_local = "home" in mercado
+    es_minus = "minus" in mercado
+
+    if es_local and es_minus:
+        if ventaja > 0.20:
+            score += 0.40
+        elif ventaja > 0.10:
+            score += 0.25
+        else:
+            score += 0.05
+    elif not es_local and es_minus:
+        if ventaja < -0.20:
+            score += 0.35
+        elif ventaja < -0.10:
+            score += 0.20
+        else:
+            score += 0.05
+    elif es_local and not es_minus:
+        if abs(ventaja) < 0.15:
+            score += 0.30
+        else:
+            score += 0.10
+    else:
+        if abs(ventaja) < 0.15:
+            score += 0.30
+        else:
+            score += 0.10
+
+    if h2h_goles >= 2.8:
+        score += 0.25
+    else:
+        score += 0.10
+
+    forma_fav = forma_local if es_local else forma_visit
+    if forma_fav > 0.6:
+        score += 0.25
+    elif forma_fav > 0.5:
+        score += 0.15
+
+    return max(0.0, min(1.0, score))
+
+
+def _analizar_contexto_1h_2h(analisis: Dict[str, Any], periodo: str, mercado: str) -> float:
+    """Analisis contextual para Primera/Segunda Mitad (solo over y ganador)."""
+    rend = analisis.get("rendimiento_equipos", {})
+    forma_local = rend.get("forma_local", 0.5)
+    forma_visit = rend.get("forma_visitante", 0.5)
+
+    if periodo == "1H":
+        pm_data = analisis.get("probabilidades_primera_mitad", {})
+        goles_esp = pm_data.get("goles_esperados_1h", 1.2)
+    else:
+        pm_data = analisis.get("probabilidades_segunda_mitad", {})
+        goles_esp = pm_data.get("goles_2h_esperados", 1.3)
+
+    score = 0.0
+
+    if "over" in mercado:
+        try:
+            num = mercado.replace("over_", "").replace("_1h", "").replace("_2h", "")
+            linea = float(num) / 10.0 if len(num) <= 2 else float(num)
+        except (ValueError, IndexError):
+            linea = 0.5
+
+        margen = goles_esp - linea
+        if margen > 0.5:
+            score += 0.40
+        elif margen > 0.2:
+            score += 0.25
+        else:
+            score += 0.08
+
+        if forma_local > 0.5 and forma_visit > 0.4:
+            score += 0.30
+        else:
+            score += 0.10
+
+        if goles_esp >= 1.5:
+            score += 0.20
+        elif goles_esp >= 1.0:
+            score += 0.10
+
+    elif "result_1" in mercado or "result_2" in mercado:
+        ventaja = rend.get("ventaja_local", 0)
+        if "result_1" in mercado:
+            if ventaja > 0.15:
+                score += 0.35
+            elif ventaja > 0.05:
+                score += 0.20
+            else:
+                score += 0.05
+        else:
+            if ventaja < -0.15:
+                score += 0.35
+            elif ventaja < -0.05:
+                score += 0.20
+            else:
+                score += 0.05
+
+        forma_fav = forma_local if "result_1" in mercado else forma_visit
+        if forma_fav > 0.6:
+            score += 0.30
+        elif forma_fav > 0.5:
+            score += 0.15
+
+        score += 0.15
+
+    return max(0.0, min(1.0, score))
+
+
+# ═══════════════════════════════════════════════════════════════
+#  MOTOR DE SCORING V2
+# ═══════════════════════════════════════════════════════════════
+
+def _obtener_contexto_mercado(analisis: Dict[str, Any], tipo: str, mercado: str) -> float:
+    """Router: obtiene el score contextual para cualquier tipo de mercado"""
+    if tipo == "1X2":
+        return _analizar_contexto_1x2(analisis, mercado)
+    elif tipo == "BTTS":
+        return _analizar_contexto_btts(analisis)
+    elif tipo == "Over/Under":
+        try:
+            num = mercado.replace("over_", "")
+            linea = float(num) / 10.0
+        except (ValueError, AttributeError):
+            linea = 2.5
+        return _analizar_contexto_over_goles(analisis, linea)
+    elif tipo == "Corners":
+        try:
+            num = mercado.replace("over_", "")
+            linea = float(num) / 10.0
+        except (ValueError, AttributeError):
+            linea = 9.5
+        return _analizar_contexto_corners(analisis, linea)
+    elif tipo == "Tarjetas":
+        try:
+            num = mercado.replace("over_", "").replace("_cards", "")
+            linea = float(num) / 10.0
+        except (ValueError, AttributeError):
+            linea = 4.5
+        return _analizar_contexto_tarjetas(analisis, linea)
+    elif tipo == "DC":
+        return _analizar_contexto_dc(analisis, mercado)
+    elif tipo == "Handicap":
+        return _analizar_contexto_handicap(analisis, mercado)
+    elif tipo in ("1H", "2H"):
+        return _analizar_contexto_1h_2h(analisis, tipo, mercado)
+    else:
+        return 0.3
+
+
+def _calcular_score_v2(tipo: str, cuota: float, ev: float, probabilidad: float,
+                       contexto: float) -> float:
+    """Scoring V2: combina EV, contexto, probabilidad, y bonus de rango."""
+    cfg = cargar_configuracion_v2()
+    weights = V2_MARKET_WEIGHTS.get(tipo, [0.30, 0.30, 0.25, 0.15])
+    w_ev, w_ctx, w_prob, w_range = weights
+
+    ev_score = min(ev / 0.40, 1.0)
+    ctx_score = contexto
+    prob_score = min(probabilidad / 0.80, 1.0)
+
+    if cfg["odds_pri_min"] <= cuota <= cfg["odds_pri_max"]:
+        range_bonus = 1.0
+    elif cfg["odds_min"] <= cuota < cfg["odds_pri_min"]:
+        range_bonus = 0.5
+    elif cfg["odds_pri_max"] < cuota <= cfg["odds_max"]:
+        range_bonus = 0.7
+    else:
+        range_bonus = 0.0
+
+    return (ev_score * w_ev) + (ctx_score * w_ctx) + (prob_score * w_prob) + (range_bonus * w_range)
+
+
+# ═══════════════════════════════════════════════════════════════
+#  MOTOR DE SELECCION V2
+# ═══════════════════════════════════════════════════════════════
+
+def encontrar_mejores_apuestas_v2(analisis: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """
+    Motor V2: Pipeline completo de seleccion de apuestas rentables.
+    1. Genera mercados  2. Filtra prohibidos  3. Filtra cuota/EV
+    4. Confianza por tipo  5. Scoring contextual  6. Diversifica  7. Top 3
+    """
+    candidatos = []
+    cfg = cargar_configuracion_v2()
+    cuotas_reales = analisis["cuotas_disponibles"]
+    mercados_disponibles = _construir_mercados(analisis, cuotas_reales)
+
+    for tipo_mercado, mercado, probabilidad, cuota_str, descripcion in mercados_disponibles:
+        try:
+            cuota_real = float(cuota_str)
+            if cuota_real <= 1.0:
+                continue
+
+            # FILTRO 1: Mercados prohibidos
+            if mercado.lower() in V2_MERCADOS_PROHIBIDOS:
+                continue
+            desc_lower = descripcion.lower()
+            if "menos" in desc_lower or "under" in desc_lower:
+                continue
+            if "empate" in desc_lower and tipo_mercado in ("1X2", "1H", "2H"):
+                continue
+
+            # FILTRO 2: Cuota minima/maxima
+            if cuota_real < cfg["odds_min"] or cuota_real > cfg["odds_max"]:
+                continue
+
+            # FILTRO 3: EV minimo
+            ve = (probabilidad * cuota_real) - 1
+            en_rango = cfg["odds_pri_min"] <= cuota_real <= cfg["odds_pri_max"]
+            if en_rango:
+                if ve < cfg["ev_min"]:
+                    continue
+            else:
+                if ve < V2_EV_OVERRIDE_THRESHOLD:
+                    continue
+
+            # FILTRO 4: Confianza minima por tipo
+            umbral = V2_CONFIDENCE_THRESHOLDS.get(tipo_mercado, 0.45)
+            if probabilidad < umbral:
+                continue
+
+            # SCORING contextual
+            contexto = _obtener_contexto_mercado(analisis, tipo_mercado, mercado)
+            score = _calcular_score_v2(tipo_mercado, cuota_real, ve, probabilidad, contexto)
+
+            candidatos.append({
+                "tipo": tipo_mercado,
+                "mercado": mercado,
+                "descripcion": descripcion,
+                "probabilidad": probabilidad,
+                "cuota": cuota_real,
+                "valor_esperado": ve,
+                "edge_percentage": ve * 100,
+                "confianza": probabilidad * 100,
+                "stake_recomendado": min(10, max(1, int(abs(ve) * 50))),
+                "source": "api",
+                "score_v2": score,
+                "contexto_score": contexto,
+                "en_rango_prioritario": en_rango,
+                "justificacion": "",
+            })
+
+        except (ValueError, TypeError):
+            continue
+
+    if not candidatos:
+        return []
+
+    candidatos.sort(key=lambda x: x["score_v2"], reverse=True)
+
+    # DIVERSIFICACION: max 2 del mismo tipo
+    seleccionados = []
+    conteo_tipos = {}
+    for c in candidatos:
+        tipo = c["tipo"]
+        count = conteo_tipos.get(tipo, 0)
+        if count >= V2_MAX_SAME_MARKET:
+            continue
+        seleccionados.append(c)
+        conteo_tipos[tipo] = count + 1
+        if len(seleccionados) >= cfg["max_picks"]:
+            break
+
+    # POST-PROCESO: Kelly stake + justificaciones
+    for pick in seleccionados:
+        if pick["cuota"] > 1:
+            kelly = pick["valor_esperado"] / (pick["cuota"] - 1)
+            pick["stake_recomendado"] = min(10, max(1, int(kelly * 100)))
+        pick["justificacion"] = _generar_justificacion_v2(pick, analisis)
+
+    return seleccionados
+
+
+def _construir_mercados(analisis: Dict[str, Any], cuotas_reales: Dict) -> List[tuple]:
+    """Construye la lista de mercados V2 (solo ofensivos/rentables)"""
+    parts = analisis['partido'].split(' vs ')
+    loc = parts[0] if len(parts) > 1 else "Local"
+    vis = parts[1] if len(parts) > 1 else "Visitante"
+
+    return [
+        # 1X2 (sin empate)
+        ("1X2", "local", analisis["probabilidades_1x2"]["local"],
+         cuotas_reales.get("local", "0"), f"Victoria {loc}"),
+        ("1X2", "visitante", analisis["probabilidades_1x2"]["visitante"],
+         cuotas_reales.get("visitante", "0"), f"Victoria {vis}"),
+        # BTTS SI
+        ("BTTS", "btts_si", analisis.get("probabilidades_btts", {}).get("btts_si", 0.5),
+         cuotas_reales.get("btts_si", "0"), "Ambos equipos marcan - SI"),
+        # Over Goles
+        ("Over/Under", "over_15", analisis.get("probabilidades_over_under", {}).get("over_15", 0.8),
+         cuotas_reales.get("over_15", "0"), "Mas de 1.5 goles"),
+        ("Over/Under", "over_25", analisis.get("probabilidades_over_under", {}).get("over_25", 0.6),
+         cuotas_reales.get("over_25", "0"), "Mas de 2.5 goles"),
+        ("Over/Under", "over_35", analisis.get("probabilidades_over_under", {}).get("over_35", 0.4),
+         cuotas_reales.get("over_35", "0"), "Mas de 3.5 goles"),
+        ("Over/Under", "over_45", analisis.get("probabilidades_over_under", {}).get("over_45", 0.2),
+         cuotas_reales.get("over_45", "0"), "Mas de 4.5 goles"),
+        # 1H Over + Ganador
+        ("1H", "over_05_1h", analisis.get("probabilidades_primera_mitad", {}).get("over_05_1h", 0.6),
+         cuotas_reales.get("1h_over_05", "0"), "Mas de 0.5 goles 1H"),
+        ("1H", "over_15_1h", analisis.get("probabilidades_primera_mitad", {}).get("over_15_1h", 0.3),
+         cuotas_reales.get("1h_over_15", "0"), "Mas de 1.5 goles 1H"),
+        ("1H", "result_1_1h", analisis.get("probabilidades_primera_mitad", {}).get("result_1_1h", 0.35),
+         cuotas_reales.get("1h_result_1", "0"), f"Victoria {loc} 1H"),
+        ("1H", "result_2_1h", analisis.get("probabilidades_primera_mitad", {}).get("result_2_1h", 0.35),
+         cuotas_reales.get("1h_result_2", "0"), f"Victoria {vis} 1H"),
+        # 2H Over + Ganador
+        ("2H", "over_05_2h", analisis.get("probabilidades_segunda_mitad", {}).get("over_05_2h", 0.5),
+         cuotas_reales.get("2h_over_05", "0"), "Mas de 0.5 goles 2H"),
+        ("2H", "over_15_2h", analisis.get("probabilidades_segunda_mitad", {}).get("over_15_2h", 0.3),
+         cuotas_reales.get("2h_over_15", "0"), "Mas de 1.5 goles 2H"),
+        ("2H", "result_1_2h", analisis.get("probabilidades_segunda_mitad", {}).get("result_1_2h", 0.3),
+         cuotas_reales.get("2h_result_1", "0"), f"Victoria {loc} 2H"),
+        ("2H", "result_2_2h", analisis.get("probabilidades_segunda_mitad", {}).get("result_2_2h", 0.3),
+         cuotas_reales.get("2h_result_2", "0"), f"Victoria {vis} 2H"),
+        # Double Chance
+        ("DC", "1x", analisis.get("probabilidades_double_chance", {}).get("dc_1x", 0.7),
+         cuotas_reales.get("dc_1x", "0"), f"{loc} o Empate"),
+        ("DC", "12", analisis.get("probabilidades_double_chance", {}).get("dc_12", 0.7),
+         cuotas_reales.get("dc_12", "0"), f"{loc} o {vis}"),
+        ("DC", "x2", analisis.get("probabilidades_double_chance", {}).get("dc_x2", 0.7),
+         cuotas_reales.get("dc_x2", "0"), f"Empate o {vis}"),
+        # Corners Over
+        ("Corners", "over_85", analisis.get("probabilidades_corners", {}).get("over_85_corners", 0.6),
+         cuotas_reales.get("corners_over_85", "0"), "Mas de 8.5 corners"),
+        ("Corners", "over_95", analisis.get("probabilidades_corners", {}).get("over_105_corners", 0.5),
+         cuotas_reales.get("corners_over_95", "0"), "Mas de 9.5 corners"),
+        ("Corners", "over_105", analisis.get("probabilidades_corners", {}).get("over_105_corners", 0.4),
+         cuotas_reales.get("corners_over_105", "0"), "Mas de 10.5 corners"),
+        ("Corners", "over_115", analisis.get("probabilidades_corners", {}).get("over_115_corners", 0.3),
+         cuotas_reales.get("corners_over_115", "0"), "Mas de 11.5 corners"),
+        # Tarjetas Over
+        ("Tarjetas", "over_35", analisis.get("probabilidades_tarjetas", {}).get("over_35_cards", 0.6),
+         cuotas_reales.get("cards_over_35", "0"), "Mas de 3.5 tarjetas"),
+        ("Tarjetas", "over_45", analisis.get("probabilidades_tarjetas", {}).get("over_45_cards", 0.4),
+         cuotas_reales.get("cards_over_45", "0"), "Mas de 4.5 tarjetas"),
+        ("Tarjetas", "over_55", analisis.get("probabilidades_tarjetas", {}).get("over_55_cards", 0.3),
+         cuotas_reales.get("cards_over_55", "0"), "Mas de 5.5 tarjetas"),
+        # Handicap
+        ("Handicap", "home_minus_05", analisis.get("probabilidades_handicap", {}).get("handicap_local_05", 0.5),
+         cuotas_reales.get("handicap_home_minus_05", "0"), f"{loc} -0.5"),
+        ("Handicap", "home_plus_05", analisis.get("probabilidades_handicap", {}).get("handicap_local_05", 0.5),
+         cuotas_reales.get("handicap_home_plus_05", "0"), f"{loc} +0.5"),
+        ("Handicap", "away_minus_05", analisis.get("probabilidades_handicap", {}).get("handicap_visitante_05", 0.5),
+         cuotas_reales.get("handicap_away_minus_05", "0"), f"{vis} -0.5"),
+        ("Handicap", "away_plus_05", analisis.get("probabilidades_handicap", {}).get("handicap_visitante_05", 0.5),
+         cuotas_reales.get("handicap_away_plus_05", "0"), f"{vis} +0.5"),
+        ("Handicap", "home_minus_10", analisis.get("probabilidades_handicap", {}).get("handicap_local_10", 0.4),
+         cuotas_reales.get("handicap_home_minus_10", "0"), f"{loc} -1.0"),
+        ("Handicap", "away_minus_10", analisis.get("probabilidades_handicap", {}).get("handicap_visitante_10", 0.4),
+         cuotas_reales.get("handicap_away_minus_10", "0"), f"{vis} -1.0"),
+    ]
+
+
+def _generar_justificacion_v2(pick: Dict[str, Any], analisis: Dict[str, Any]) -> str:
+    """Genera justificacion V2 con analisis contextual detallado"""
+    ve_pct = round(pick["valor_esperado"] * 100, 1)
+    conf_pct = round(pick["confianza"], 1)
+    cuota = pick["cuota"]
+    ctx = round(pick.get("contexto_score", 0) * 100, 0)
+    en_rango = pick.get("en_rango_prioritario", False)
+    tipo = pick["tipo"]
+    rend = analisis.get("rendimiento_equipos", {})
+
+    tag = "PRIORITARIO" if en_rango else "EV OVERRIDE"
+    base = f"[V2 {tag}] Cuota {cuota:.2f} | EV: +{ve_pct}% | Ctx: {ctx:.0f}%"
+
+    detalles = {
+        "1X2": (
+            f"Forma: {rend.get('forma_local', 0.5):.2f} vs {rend.get('forma_visitante', 0.5):.2f} | "
+            f"Ventaja: {rend.get('ventaja_local', 0):+.2f}"
+        ),
+        "BTTS": (
+            f"Goles prom: {rend.get('goles_promedio_local', 1.3):.1f} + "
+            f"{rend.get('goles_promedio_visitante', 1.3):.1f} | "
+            f"H2H: {rend.get('h2h_goles_total', 2.7):.1f} goles"
+        ),
+        "Over/Under": (
+            f"Goles esp: {analisis.get('probabilidades_over_under', {}).get('goles_esperados', 2.7):.1f} | "
+            f"Ofensiva: {rend.get('goles_promedio_local', 1.3):.1f}+{rend.get('goles_promedio_visitante', 1.3):.1f}"
+        ),
+        "Corners": (
+            f"Factor corners: {rend.get('corners_promedio', 1.0):.2f}x | "
+            f"Estilo ofensivo: {'Si' if rend.get('forma_local', 0.5) > 0.5 else 'Moderado'}"
+        ),
+        "Tarjetas": (
+            f"Factor disciplina: {rend.get('tarjetas_promedio', 1.0):.2f}x | "
+            f"Intensidad: {'Alta' if abs(rend.get('ventaja_local', 0)) < 0.15 else 'Media'}"
+        ),
+        "DC": (
+            f"Prob combinada alta | "
+            f"Forma: {rend.get('forma_local', 0.5):.2f} vs {rend.get('forma_visitante', 0.5):.2f}"
+        ),
+        "Handicap": (
+            f"Ventaja: {rend.get('ventaja_local', 0):+.2f} | "
+            f"H2H goles: {rend.get('h2h_goles_total', 2.7):.1f}"
+        ),
+        "1H": f"Goles esp 1H: {analisis.get('probabilidades_primera_mitad', {}).get('goles_esperados_1h', 1.2):.1f}",
+        "2H": f"Goles esp 2H: {analisis.get('probabilidades_segunda_mitad', {}).get('goles_2h_esperados', 1.3):.1f}",
+    }
+
+    detalle = detalles.get(tipo, "")
+    if detalle:
+        base += f" | {detalle}"
+
+    return base
+
+
+# ═══════════════════════════════════════════════════════════════
+#  API PUBLICA - Funciones que usa el GUI
+# ═══════════════════════════════════════════════════════════════
+
+def generar_prediccion_v2(partido: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Genera prediccion con algoritmo V2"""
+    try:
+        analisis = analizar_partido_completo(partido)
+        mejores = encontrar_mejores_apuestas_v2(analisis)
+
+        if not mejores:
+            return None
+
+        if not es_liga_conocida(analisis["liga"]):
+            return None
+
+        mejor = mejores[0]
+
+        return {
+            "partido": analisis["partido"],
+            "liga": analisis["liga"],
+            "hora": analisis["hora"],
+            "prediccion": mejor["descripcion"],
+            "cuota": mejor["cuota"],
+            "stake_recomendado": mejor["stake_recomendado"],
+            "confianza": round(mejor["confianza"], 1),
+            "valor_esperado": round(mejor["valor_esperado"], 3),
+            "razon": mejor["justificacion"],
+            "score_v2": round(mejor["score_v2"], 3),
+            "contexto_score": round(mejor.get("contexto_score", 0), 3),
+            "tipo_mercado": mejor["tipo"],
+            "en_rango_prioritario": mejor["en_rango_prioritario"],
+            "algoritmo": "v2",
+            "opcion_numero": 1,
+            "total_opciones": len(mejores),
+        }
+    except Exception as e:
+        print(f"[V2] Error generando prediccion: {e}")
+        return None
+
+
+def filtrar_apuestas_inteligentes_v2(partidos: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    Filtra picks V2 — menos picks, mayor rentabilidad.
+    Maximo 3 picks por defecto (configurable).
+    """
+    predicciones_validas = []
+    fecha = datetime.now().strftime('%Y-%m-%d')
+    cfg = cargar_configuracion_v2()
+
+    for partido in partidos:
+        try:
+            clave = f"{partido.get('local', '')}|{partido.get('visitante', '')}|{fecha}|v2"
+
+            if clave in _cache_predicciones_v2:
+                prediccion = _cache_predicciones_v2[clave]
+            else:
+                partido_con_fecha = {**partido, 'fecha': fecha}
+                prediccion = generar_prediccion_v2(partido_con_fecha)
+                if prediccion:
+                    _cache_predicciones_v2[clave] = prediccion
+
+            if prediccion:
+                predicciones_validas.append(prediccion)
+        except Exception as e:
+            print(f"[V2] Error: {partido.get('local', '?')} vs {partido.get('visitante', '?')}: {e}")
+            continue
+
+    predicciones_validas.sort(key=lambda x: x.get("score_v2", 0), reverse=True)
+
+    # Diversificacion global
+    resultado = []
+    conteo = {}
+    for p in predicciones_validas:
+        tipo = p.get("tipo_mercado", "")
+        c = conteo.get(tipo, 0)
+        if c >= V2_MAX_SAME_MARKET:
+            continue
+        resultado.append(p)
+        conteo[tipo] = c + 1
+        if len(resultado) >= cfg["max_picks"]:
+            break
+
+    return resultado
+
+
+def generar_mensaje_v2(predicciones: List[Dict[str, Any]], fecha: str,
+                       counter_numbers: Optional[List[int]] = None) -> str:
+    """Genera mensaje Telegram para picks V2"""
+    cfg = cargar_configuracion_v2()
+
+    if not predicciones:
+        return (
+            f"BETGENIUX V2 ({fecha})\n\n"
+            f"No se encontraron picks V2 para hoy.\n"
+            f"Criterios: Cuotas {cfg['odds_pri_min']}-{cfg['odds_pri_max']}, "
+            f"EV alto, max {cfg['max_picks']} picks."
+        )
+
+    if counter_numbers is None:
+        try:
+            from daily_counter import get_next_pronostico_numbers
+            counter_numbers = get_next_pronostico_numbers(len(predicciones))
+        except ImportError:
+            counter_numbers = list(range(1, len(predicciones) + 1))
+
+    mensaje = f"BETGENIUX V2 ({fecha})\n"
+    mensaje += "Algoritmo experimental - Rentabilidad maxima\n\n"
+
+    for i, pred in enumerate(predicciones):
+        numero = counter_numbers[i] if i < len(counter_numbers) else i + 1
+        rango_tag = "PRIORITARIO" if pred.get('en_rango_prioritario', False) else "EV ALTO"
+        tipo = pred.get('tipo_mercado', '')
+
+        mensaje += f"PRONOSTICO V2 #{numero} [{rango_tag}] [{tipo}]\n"
+        mensaje += f"{pred['liga']}\n"
+        mensaje += f"{pred['partido']}\n"
+        mensaje += f"{pred['prediccion']}\n"
+        mensaje += f"Cuota: {pred['cuota']} | Stake: {pred['stake_recomendado']}u\n"
+        mensaje += f"Confianza: {pred['confianza']}% | EV: +{pred['valor_esperado']}\n"
+        mensaje += f"{pred['hora']}\n\n"
+
+    mensaje += "Apostar con responsabilidad\n"
+    mensaje += (
+        f"V2: Prioriza cuotas {cfg['odds_pri_min']}-{cfg['odds_pri_max']} | "
+        f"Max {cfg['max_picks']} picks | Sin unders"
+    )
+
+    return mensaje

--- a/sergiobets_unified.py
+++ b/sergiobets_unified.py
@@ -38,6 +38,7 @@ from footystats_api import obtener_partidos_del_dia
 from json_storage import guardar_json, cargar_json
 from telegram_utils import enviar_telegram, enviar_telegram_masivo
 from ia_bets import filtrar_apuestas_inteligentes, generar_mensaje_ia, simular_datos_prueba, limpiar_cache_predicciones, guardar_prediccion_historica
+from ia_bets_v2 import filtrar_apuestas_inteligentes_v2, generar_mensaje_v2, limpiar_cache_predicciones_v2
 from league_utils import detectar_liga_por_imagen
 from track_record import TrackRecordManager
 
@@ -698,6 +699,14 @@ class SergioBetsUnified:
         self._combo_conf.pack(side='left', padx=(0, 16))
         self._combo_conf.set('Todas')
 
+        v2_btn = tk.Button(fbar, text="V2", bg='#F59E0B',
+                            fg='#FFFFFF', font=('Segoe UI', 10, 'bold'), relief='flat',
+                            cursor='hand2', padx=12, pady=4, bd=0,
+                            activebackground='#D97706',
+                            activeforeground='#FFFFFF', command=self.buscar_v2_en_hilo)
+        v2_btn.pack(side='right', padx=(0, 8))
+        self._v2_btn = v2_btn
+
         gen_btn = tk.Button(fbar, text="Generar Pronosticos", bg=palette['primary'],
                             fg='#FFFFFF', font=('Segoe UI', 10, 'bold'), relief='flat',
                             cursor='hand2', padx=16, pady=4, bd=0,
@@ -1089,6 +1098,40 @@ class SergioBetsUnified:
         self._rend_table_container = table_container
         self._rend_table_body_start_row = 2
 
+        # ── Algorithm Comparison Table (V1 vs V2) ──────────────────
+        algo_card = tk.Frame(self._rendimiento_frame, bg=p['card_bg'], padx=16, pady=8,
+                              highlightbackground=p['card_border'], highlightthickness=1)
+        algo_card.grid(row=4, column=0, sticky='ew', pady=(0, 4))
+
+        tk.Label(algo_card, text="Comparacion Algoritmos: V1 vs V2",
+                 bg=p['card_bg'], fg=p['fg'],
+                 font=('Segoe UI', 10, 'bold')).pack(anchor='w', pady=(0, 4))
+
+        algo_table = tk.Frame(algo_card, bg=p['card_bg'])
+        algo_table.pack(fill='x')
+        algo_col_weights = [2, 1, 1, 1, 1, 1]
+        for c, w in enumerate(algo_col_weights):
+            algo_table.grid_columnconfigure(c, weight=w, uniform='algo_col')
+
+        algo_headers = [
+            ("Algoritmo", 'w'),
+            ("Aciertos", 'center'),
+            ("Fallos", 'center'),
+            ("Cuota Prom.", 'center'),
+            ("Win Rate", 'center'),
+            ("Profit", 'e'),
+        ]
+        for c, (text, anc) in enumerate(algo_headers):
+            tk.Label(algo_table, text=text, bg=p['card_bg'], fg=p['muted'],
+                     font=('Segoe UI', 8, 'bold'), anchor=anc).grid(
+                row=0, column=c, sticky='ew', padx=6, pady=(0, 3))
+
+        algo_sep = tk.Frame(algo_table, bg=p['card_border'], height=1)
+        algo_sep.grid(row=1, column=0, columnspan=6, sticky='ew', pady=(0, 2))
+
+        self._algo_table_container = algo_table
+        self._algo_table_body_start_row = 2
+
     def _refresh_rendimiento_data(self):
         """Refresh the rendimiento page with real data"""
         import tkinter as tk
@@ -1235,6 +1278,55 @@ class SergioBetsUnified:
             tk.Label(self._rend_table_container, text=f"{t_sign}${total_pl:,.0f} COP", bg=p['card_bg'], fg=t_color,
                      font=('Segoe UI', 9, 'bold'), anchor='e').grid(
                 row=total_row, column=4, sticky='ew', padx=6, pady=1)
+
+        # ── Update Algorithm Comparison Table ──────────────────
+        if hasattr(self, '_algo_table_container'):
+            start = self._algo_table_body_start_row
+            for w in self._algo_table_container.grid_slaves():
+                info = w.grid_info()
+                if int(info.get('row', 0)) >= start:
+                    w.destroy()
+
+            for row_idx, algo_name in enumerate(['v1', 'v2']):
+                algo_bets = [pr for pr in enviados
+                             if pr.get('algoritmo', 'v1') == algo_name and pr.get('acierto') is not None]
+                a_wins = sum(1 for b in algo_bets if b.get('acierto') is True)
+                a_losses = sum(1 for b in algo_bets if b.get('acierto') is False)
+                a_cuotas = [float(b.get('cuota', 1)) for b in algo_bets]
+                a_avg_cuota = sum(a_cuotas) / len(a_cuotas) if a_cuotas else 0
+                a_profit = 0
+                for bet in algo_bets:
+                    cuota = float(bet.get('cuota', 1))
+                    if bet.get('acierto') is True:
+                        a_profit += STAKE * cuota - STAKE
+                    else:
+                        a_profit -= STAKE
+                a_wr = (a_wins / len(algo_bets) * 100) if algo_bets else 0
+                a_sign = '+' if a_profit >= 0 else ''
+                a_color = '#10B981' if a_profit >= 0 else '#EF4444'
+                display_name = 'Algoritmo V1 (Actual)' if algo_name == 'v1' else 'Algoritmo V2 (Experimental)'
+                accent = '#3B82F6' if algo_name == 'v1' else '#F59E0B'
+                r = start + row_idx
+
+                tk.Label(self._algo_table_container, text=display_name, bg=p['card_bg'], fg=accent,
+                         font=('Segoe UI', 9, 'bold'), anchor='w').grid(
+                    row=r, column=0, sticky='ew', padx=6, pady=2)
+                tk.Label(self._algo_table_container, text=str(a_wins), bg=p['card_bg'], fg='#10B981',
+                         font=('Segoe UI', 9), anchor='center').grid(
+                    row=r, column=1, sticky='ew', padx=6, pady=2)
+                tk.Label(self._algo_table_container, text=str(a_losses), bg=p['card_bg'], fg='#EF4444',
+                         font=('Segoe UI', 9), anchor='center').grid(
+                    row=r, column=2, sticky='ew', padx=6, pady=2)
+                tk.Label(self._algo_table_container, text=f"{a_avg_cuota:.2f}" if a_avg_cuota else "-", bg=p['card_bg'], fg=p['fg'],
+                         font=('Segoe UI', 9), anchor='center').grid(
+                    row=r, column=3, sticky='ew', padx=6, pady=2)
+                tk.Label(self._algo_table_container, text=f"{a_wr:.1f}%" if algo_bets else "-", bg=p['card_bg'], fg=p['fg'],
+                         font=('Segoe UI', 9), anchor='center').grid(
+                    row=r, column=4, sticky='ew', padx=6, pady=2)
+                tk.Label(self._algo_table_container, text=f"{a_sign}${a_profit:,.0f} COP" if algo_bets else "Sin datos",
+                         bg=p['card_bg'], fg=a_color if algo_bets else p['muted'],
+                         font=('Segoe UI', 9, 'bold'), anchor='e').grid(
+                    row=r, column=5, sticky='ew', padx=6, pady=2)
 
     def _draw_rendimiento_chart(self, daily_pl, cumulative, day_labels):
         """Draw the full-page weekly bar chart on the rendimiento canvas"""
@@ -3529,6 +3621,70 @@ class SergioBetsUnified:
         except ImportError:
             threading.Thread(target=lambda: self.buscar(opcion_numero=2)).start()
 
+    def buscar_v2_en_hilo(self):
+        """Buscar con algoritmo V2 en hilo separado"""
+        try:
+            from thread_pool_manager import thread_manager
+            executor = thread_manager.get_executor()
+            executor.submit(self.buscar_v2)
+        except ImportError:
+            threading.Thread(target=self.buscar_v2).start()
+
+    def buscar_v2(self):
+        """Buscar partidos y generar predicciones con algoritmo V2"""
+        try:
+            fecha = self.entry_fecha.get()
+            self.ligas_disponibles.clear()
+
+            limpiar_cache_predicciones_v2()
+
+            partidos = self.cargar_partidos_reales(fecha)
+
+            self.limpiar_frame_predicciones()
+            self.limpiar_frame_partidos()
+
+            if not partidos or len(partidos) == 0:
+                self.actualizar_ligas()
+                self.mensaje_telegram = f"No hay partidos disponibles para {fecha}"
+                messagebox.showinfo("Sin partidos", f"No hay partidos disponibles para {fecha}\nIntenta con otra fecha que tenga partidos programados")
+                return
+
+            for partido in partidos:
+                liga = partido["liga"]
+                self.ligas_disponibles.add(liga)
+
+            self.actualizar_ligas()
+
+            liga_filtrada = self.combo_ligas.get()
+            if liga_filtrada not in ['Todas'] + sorted(list(self.ligas_disponibles)):
+                self.combo_ligas.set('Todas')
+                liga_filtrada = 'Todas'
+
+            if liga_filtrada == 'Todas':
+                partidos_filtrados = partidos
+            else:
+                partidos_filtrados = [p for p in partidos if p["liga"] == liga_filtrada]
+
+            predicciones_v2 = filtrar_apuestas_inteligentes_v2(partidos_filtrados)
+
+            # Tag all V2 predictions with algorithm version
+            for pred in predicciones_v2:
+                pred['algoritmo'] = 'v2'
+
+            titulo_extra = " - ALGORITMO V2 (Experimental)"
+            self.mostrar_predicciones_con_checkboxes(predicciones_v2, liga_filtrada, titulo_extra)
+            self.mostrar_partidos_con_checkboxes(partidos_filtrados, liga_filtrada, fecha)
+
+            preview_counter_numbers = list(range(1, len(predicciones_v2) + 1))
+            self.mensaje_telegram = generar_mensaje_v2(predicciones_v2, fecha, preview_counter_numbers)
+
+            self.guardar_datos_json(fecha)
+
+        except Exception as e:
+            error_msg = f"Error al buscar con V2: {e}"
+            print(error_msg)
+            messagebox.showerror("Error V2", f"Error al generar pronosticos V2: {e}")
+
     def buscar(self, opcion_numero=1):
         """Buscar partidos y predicciones"""
         try:
@@ -3566,7 +3722,11 @@ class SergioBetsUnified:
                 partidos_filtrados = [p for p in partidos if p["liga"] == liga_filtrada]
             
             predicciones_ia = filtrar_apuestas_inteligentes(partidos_filtrados, opcion_numero)
-            
+
+            # Tag all V1 predictions with algorithm version
+            for pred in predicciones_ia:
+                pred['algoritmo'] = 'v1'
+
             config = self.cargar_configuracion()
             odds_min = config.get("odds_min", 1.30)
             odds_max = config.get("odds_max", 1.60)
@@ -4352,6 +4512,15 @@ class SergioBetsUnified:
                     pred['sent_to_telegram'] = True
                     pred['fecha_envio_telegram'] = hora_bogota().isoformat()
                     guardar_prediccion_historica(pred, fecha)
+                    # Patch historial to include algorithm version
+                    try:
+                        hist = cargar_json('historial_predicciones.json') or []
+                        if hist:
+                            hist[-1]['algoritmo'] = pred.get('algoritmo', 'v1')
+                            from json_storage import guardar_json as _gj
+                            _gj('historial_predicciones.json', hist)
+                    except Exception:
+                        pass
                 
                 with open("pronosticos_seleccionados.json", "w", encoding="utf-8") as f:
                     json.dump({"fecha": fecha, "predicciones": predicciones_seleccionadas}, f, ensure_ascii=False, indent=4)


### PR DESCRIPTION
## Summary

Adds a parallel experimental algorithm (V2) that runs **independently** alongside the existing V1 algorithm. V1 (`ia_bets.py`) is **completely untouched**. The goal is A/B testing: both algorithms analyze the same matches, but V2 targets higher-odds picks (1.75–2.10) with market-specific contextual analysis, while V1 continues operating as before.

**New file: `ia_bets_v2.py` (~950 lines)**
- Eliminates defensive bets (under goals, under corners, under cards, draws)
- Implements 8 market-specific context analyzers (1X2, BTTS, Over/Under, Corners, Cards, Double Chance, Handicap, 1H/2H)
- Weighted scoring system per market type
- Stricter filters: min odds 1.65, priority range 1.75–2.10, min EV 8%, max 3 picks/day
- Imports analysis functions from `ia_bets.py` but builds its own filtering/scoring/selection pipeline

**GUI changes in `sergiobets_unified.py`:**
- Yellow "V2" button added to filter bar (next to "Generar Pronosticos")
- `buscar_v2()` method generates picks using V2 algorithm only when button is pressed
- V1 shows by default on app startup — V2 is opt-in only
- All predictions tagged with `algoritmo: "v1"` or `"v2"` when generated
- After sending to Telegram, historial JSON is patched to include the algorithm tag
- New "Comparacion Algoritmos: V1 vs V2" table in the Rendimiento module (aciertos, fallos, cuota promedio, win rate, profit)

## Review & Testing Checklist for Human

- [ ] **Verify `numpy` and `scipy` are installed** in your environment — `ia_bets_v2.py` imports both. If missing, the V2 button will crash at runtime with an ImportError.
- [ ] **Click the V2 button** on a date with matches and confirm it generates picks without errors, displays them with the "ALGORITMO V2 (Experimental)" label, and that picks have odds ≥ 1.65.
- [ ] **Click "Generar Pronosticos" (V1)** after using V2 and confirm V1 still works identically — no regressions.
- [ ] **Send a V2 pick to Telegram**, then check `historial_predicciones.json` to confirm the last entry has `"algoritmo": "v2"`. The patching logic (read-modify-write in a loop) is fragile — verify no data corruption if sending multiple picks at once.
- [ ] **Navigate to Rendimiento** and verify the "Comparacion Algoritmos" table renders correctly with V1/V2 rows (will show "Sin datos" for V2 until picks are resolved).

**Recommended test plan:** Open the app → click V2 → verify picks appear → click Generar Pronosticos → verify V1 picks appear → send one of each to Telegram → go to Rendimiento → confirm comparison table.

### Notes
- The historial patching approach (lines 4515–4523) reads and rewrites the full JSON file once per prediction in a loop. This works but is not ideal for large historial files — consider a wrapper function in the future.
- `buscar_v2()` calls `messagebox` from a background thread, which is technically unsafe in Tkinter. This matches the existing pattern in `buscar()`, so it's consistent but worth noting.
- Historical predictions without an `algoritmo` field default to `"v1"` in the comparison table, which is the correct assumption.

Link to Devin session: https://app.devin.ai/sessions/a75fef941bba46638288ffc205b79c1e