### PR TITLE
Fix: Detección correcta de liga para partidos de Champions League y otras competiciones

### DIFF
--- a/crudo.py
+++ b/crudo.py
@@ -34,10 +34,16 @@ def cargar_partidos_reales(fecha):
             return simular_datos_prueba()
 
         for partido in datos_api:
-            liga_detectada = detectar_liga_por_imagen(
-                partido.get("home_image", ""), 
-                partido.get("away_image", "")
-            )
+            # Use competition_name from API (accurate for Champions League, Europa League, etc.)
+            # Fall back to image-based detection only if competition_name is not available
+            competition_name = partido.get("competition_name", "")
+            if competition_name:
+                liga_detectada = competition_name
+            else:
+                liga_detectada = detectar_liga_por_imagen(
+                    partido.get("home_image", ""), 
+                    partido.get("away_image", "")
+                )
             from league_utils import convertir_timestamp_unix
             hora_partido = convertir_timestamp_unix(partido.get("date_unix"))
             

--- a/sergiobets_unified.py
+++ b/sergiobets_unified.py
@@ -3487,10 +3487,16 @@ class SergioBetsUnified:
             
             for partido in datos_api:
                 try:
-                    liga_detectada = detectar_liga_por_imagen(
-                        partido.get("home_image", ""), 
-                        partido.get("away_image", "")
-                    )
+                    # Use competition_name from API (accurate for Champions League, Europa League, etc.)
+                    # Fall back to image-based detection only if competition_name is not available
+                    competition_name = partido.get("competition_name", "")
+                    if competition_name:
+                        liga_detectada = competition_name
+                    else:
+                        liga_detectada = detectar_liga_por_imagen(
+                            partido.get("home_image", ""), 
+                            partido.get("away_image", "")
+                        )
                     from league_utils import convertir_timestamp_unix
                     hora_partido = convertir_timestamp_unix(partido.get("date_unix"))
                     


### PR DESCRIPTION
## Summary

Fixes incorrect league detection for cross-league competitions (Champions League, Europa League, etc.). Previously, `detectar_liga_por_imagen()` inferred the league solely from the home team's image URL country — e.g., Arsenal's image containing "england" → "Premier League", Bayern's image containing "germany" → "Bundesliga" — even when the match was a Champions League fixture.

Now both `crudo.py` and `sergiobets_unified.py` prefer the `competition_name` field returned by the FootyStats API (which already contains the actual competition name), falling back to the image-based detection only when `competition_name` is absent or empty. This mirrors what `scheduler_service.py` already does.

## Review & Testing Checklist for Human

- [ ] **Verify `competition_name` is present in FootyStats API responses.** This is the most critical assumption. Run the app against today's matches and confirm the field exists and has reasonable values. If it's missing, the fallback to `detectar_liga_por_imagen` will trigger (same as before), so this is safe — but the fix won't take effect.
- [ ] **Check the exact string format of `competition_name`.** The old code returned curated names like "Champions League", "Premier League". The API may return different strings (e.g., "UEFA Champions League", "English Premier League"). Verify these look correct in the GUI's league filter dropdown and in Telegram messages.
- [ ] **Test Telegram output.** Send a test prediction/match list that includes a Champions League match and confirm the league label is correct in the Telegram message.

### Notes
- `scheduler_service.py` already uses `match.get('competition_name', 'Unknown')` for the same purpose, so this aligns both entry points (`crudo.py` / `sergiobets_unified.py`) with the scheduler's approach.
- `league_utils.py` and `detectar_liga_por_imagen` are left unchanged since they still serve as the fallback.

Link to Devin session: https://app.devin.ai/sessions/74fca4922dc34477833fdb82c8275ba4